### PR TITLE
Fix geometry conversions and add tests

### DIFF
--- a/geom-awt/src/main/java/com/tomgibara/geom/awt/AWTUtil.java
+++ b/geom-awt/src/main/java/com/tomgibara/geom/awt/AWTUtil.java
@@ -68,7 +68,7 @@ public class AWTUtil {
 
     public static Rect fromRectangle(Rectangle r) {
         if (r == null) throw new IllegalArgumentException("null r");
-        return Rect.atPoints(r.x, r.y, r.x + r.width, r.x + r.height);
+        return Rect.atPoints(r.x, r.y, r.x + r.width, r.y + r.height);
     }
 
     public static Rect fromRectangle(Rectangle2D.Float r) {
@@ -78,7 +78,7 @@ public class AWTUtil {
 
     public static Rect fromRectangle(Rectangle2D r) {
         if (r == null) throw new IllegalArgumentException("null r");
-        return Rect.atPoints(r.getMinY(), r.getMinY(), r.getMaxX(), r.getMaxY());
+        return Rect.atPoints(r.getMinX(), r.getMinY(), r.getMaxX(), r.getMaxY());
     }
 
     public static Line2D.Double toLine(LineSegment lineSegment) {

--- a/geom-awt/src/test/java/com/tomgibara/geom/awt/AWTUtilTest.java
+++ b/geom-awt/src/test/java/com/tomgibara/geom/awt/AWTUtilTest.java
@@ -1,0 +1,23 @@
+package com.tomgibara.geom.awt;
+
+import java.awt.Rectangle;
+import java.awt.geom.Rectangle2D;
+
+import com.tomgibara.geom.core.Rect;
+
+import junit.framework.TestCase;
+
+public class AWTUtilTest extends TestCase {
+
+    public void testFromRectangle() {
+        Rectangle r = new Rectangle(1, 2, 3, 4);
+        Rect rect = AWTUtil.fromRectangle(r);
+        assertEquals(Rect.atPoints(1, 2, 4, 6), rect);
+    }
+
+    public void testFromRectangle2D() {
+        Rectangle2D d = new Rectangle2D.Double(1.5, 2.5, 3.5, 4.5);
+        Rect rect = AWTUtil.fromRectangle(d);
+        assertEquals(Rect.atPoints(1.5, 2.5, 5.0, 7.0), rect);
+    }
+}

--- a/geom-core/src/main/java/com/tomgibara/geom/core/Point.java
+++ b/geom-core/src/main/java/com/tomgibara/geom/core/Point.java
@@ -11,7 +11,7 @@ public final class Point implements Geometric {
     public static class Util {
 
         public static Point midpoint(Point pt1, Point pt2) {
-            return midpoint(pt1.x, pt2.y, pt2.x, pt2.y);
+            return midpoint(pt1.x, pt1.y, pt2.x, pt2.y);
         }
 
         public static Point midpoint(double x1, double y1, double x2, double y2) {

--- a/geom-core/src/main/java/com/tomgibara/geom/core/Rect.java
+++ b/geom-core/src/main/java/com/tomgibara/geom/core/Rect.java
@@ -146,7 +146,7 @@ public final class Rect implements Geometric {
         double x1 = minX + offset.toMinX;
         double y1 = minY + offset.toMinY;
         double x2 = maxX + offset.toMaxX;
-        double y2 = maxX + offset.toMaxY;
+        double y2 = maxY + offset.toMaxY;
         //TODO do this more efficiently: if it flips hz or vt then slower path
         // ie if hz. growth + width < 0 flip x1 x2
         // ditto vt. growth

--- a/geom-core/src/test/java/com/tomgibara/geom/core/PointUtilTest.java
+++ b/geom-core/src/test/java/com/tomgibara/geom/core/PointUtilTest.java
@@ -1,0 +1,13 @@
+package com.tomgibara.geom.core;
+
+import junit.framework.TestCase;
+
+public class PointUtilTest extends TestCase {
+
+    public void testMidpoint() {
+        Point a = new Point(1.0, 2.0);
+        Point b = new Point(3.0, 4.0);
+        Point mid = Point.Util.midpoint(a, b);
+        assertEquals(new Point(2.0, 3.0), mid);
+    }
+}

--- a/geom-core/src/test/java/com/tomgibara/geom/core/RectOffsetTest.java
+++ b/geom-core/src/test/java/com/tomgibara/geom/core/RectOffsetTest.java
@@ -1,0 +1,14 @@
+package com.tomgibara.geom.core;
+
+import junit.framework.TestCase;
+
+public class RectOffsetTest extends TestCase {
+
+    public void testOffset() {
+        Rect r = Rect.atPoints(0, 0, 2, 2);
+        Offset o = Offset.offset(-1, 3, -2, 4);
+        Rect expected = Rect.atPoints(r.minX + o.toMinX, r.minY + o.toMinY,
+                r.maxX + o.toMaxX, r.maxY + o.toMaxY);
+        assertEquals(expected, r.offset(o));
+    }
+}


### PR DESCRIPTION
## Summary
- correct rectangle conversion helpers in AWTUtil
- fix midpoint of Points
- fix offset calculation for Rect
- add regression tests for AWTUtil, Point.Util and Rect.offset

## Testing
- `mvn -q test` *(fails: Network is unreachable while downloading dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_684d94fffbe08328b4e96b1b51ef96c8